### PR TITLE
Using correct variant of dequeueReusableCell.

### DIFF
--- a/Example/ViewAnimator/ViewControllers/ViewController.swift
+++ b/Example/ViewAnimator/ViewControllers/ViewController.swift
@@ -45,7 +45,7 @@ extension ViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "tableCell") as! TableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "tableCell", for: indexPath) as! TableViewCell
         cell.userImageView.image = UIImage(named: "\(indexPath.row)")
         return cell
     }


### PR DESCRIPTION
Nowadays UIKit forgives this mistakes. But actually, dequeueReusableCell without indexPath parameter might return nil when with indexPath parameter never returns nil.