### PR TITLE
the number of views after delay could be different from before

### DIFF
--- a/ViewAnimator/Classes/Animatable.swift
+++ b/ViewAnimator/Classes/Animatable.swift
@@ -61,8 +61,8 @@ public extension Animatable {
 
         prepareViews(initialAlpha: initialAlpha)
         let dispatchGroup = DispatchGroup()
-        for _ in 1...views.count { dispatchGroup.enter() }
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            for _ in 1...self.views.count { dispatchGroup.enter() }
             for (index, view) in self.views.enumerated() {
                 view.alpha = initialAlpha
                 view.animate(animations: animations,


### PR DESCRIPTION
the number of views after delay could be different from before. If they are different, it causes a crash at dispatch group leave, because the number of enters and leaves are not the same.