### PR TITLE
Add UIViewAnimationOptions parameter

### DIFF
--- a/ViewAnimator/Classes/ViewAnimator.swift
+++ b/ViewAnimator/Classes/ViewAnimator.swift
@@ -25,8 +25,9 @@ public extension UIView {
                         reversed: Bool = false,
                         initialAlpha: CGFloat = 0.0,
                         finalAlpha: CGFloat = 1.0,
-                        delay: Double = 0,
-                        duration: TimeInterval = ViewAnimatorConfig.duration,
+						delay: Double = 0,
+						duration: TimeInterval = ViewAnimatorConfig.duration,
+						options: UIViewAnimationOptions = [],
                         completion: (() -> Void)? = nil) {
         
         let transformFrom = transform
@@ -37,15 +38,13 @@ public extension UIView {
         }
 
         alpha = initialAlpha
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            UIView.animate(withDuration: duration, animations: { [weak self] in
-                self?.transform = reversed ? transformTo : transformFrom
-                self?.alpha = finalAlpha
-                }, completion: { _ in
-                    completion?()
-            })
-        }
+		
+		UIView.animate(withDuration: duration, delay: delay, options: options, animations: { [weak self] in
+			self?.transform = reversed ? transformTo : transformFrom
+			self?.alpha = finalAlpha
+		}) { _ in
+			completion?()
+		}
     }
     
     /// Performs the animation.
@@ -67,6 +66,7 @@ public extension UIView {
                                delay: Double = 0,
                                animationInterval: TimeInterval = 0.05,
                                duration: TimeInterval = ViewAnimatorConfig.duration,
+							   options: UIViewAnimationOptions = [],
                                completion: (() -> Void)? = nil) {
 
         guard views.count > 0 else {
@@ -86,6 +86,7 @@ public extension UIView {
                              finalAlpha: finalAlpha,
                              delay: Double(index) * animationInterval,
                              duration: duration,
+							 options: options,
                              completion: { dispatchGroup.leave() })
             }
         }

--- a/ViewAnimator/Classes/ViewAnimator.swift
+++ b/ViewAnimator/Classes/ViewAnimator.swift
@@ -25,9 +25,9 @@ public extension UIView {
                         reversed: Bool = false,
                         initialAlpha: CGFloat = 0.0,
                         finalAlpha: CGFloat = 1.0,
-						delay: Double = 0,
-						duration: TimeInterval = ViewAnimatorConfig.duration,
-						options: UIViewAnimationOptions = [],
+                        delay: Double = 0,
+                        duration: TimeInterval = ViewAnimatorConfig.duration,
+                        options: UIViewAnimationOptions = [],
                         completion: (() -> Void)? = nil) {
         
         let transformFrom = transform
@@ -38,13 +38,13 @@ public extension UIView {
         }
 
         alpha = initialAlpha
-		
-		UIView.animate(withDuration: duration, delay: delay, options: options, animations: { [weak self] in
-			self?.transform = reversed ? transformTo : transformFrom
-			self?.alpha = finalAlpha
-		}) { _ in
-			completion?()
-		}
+        
+        UIView.animate(withDuration: duration, delay: delay, options: options, animations: { [weak self] in
+            self?.transform = reversed ? transformTo : transformFrom
+            self?.alpha = finalAlpha
+        }) { _ in
+            completion?()
+        }
     }
     
     /// Performs the animation.
@@ -66,7 +66,7 @@ public extension UIView {
                                delay: Double = 0,
                                animationInterval: TimeInterval = 0.05,
                                duration: TimeInterval = ViewAnimatorConfig.duration,
-							   options: UIViewAnimationOptions = [],
+                               options: UIViewAnimationOptions = [],
                                completion: (() -> Void)? = nil) {
 
         guard views.count > 0 else {
@@ -86,7 +86,7 @@ public extension UIView {
                              finalAlpha: finalAlpha,
                              delay: Double(index) * animationInterval,
                              duration: duration,
-							 options: options,
+                             options: options,
                              completion: { dispatchGroup.leave() })
             }
         }


### PR DESCRIPTION
I've added `UIViewAnimationOptions` parameter which defaults to `[]`.

I've also changed the delay code, I think it's safe to use `delay` from `UIView.animate` here, not sure why dispatch queue was used instead. Let me know if there is a reason and I can revert it.